### PR TITLE
refactor: switch to use rems

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -3,17 +3,18 @@ body {
     display: flex;
     flex-direction: column;
     margin: 0;
+    font-size: 16px;
 }
 
 h1 {
-    font-size: 24px;
+    font-size: 1.5rem;
     color: #F9FAF8;
 }
 
 a {
     text-decoration: none;
     color: #F9FAF8;
-    padding-right: 48px;
+    padding-right: 3rem;
 }
 
 img {
@@ -33,7 +34,7 @@ p {
 .hero {
     display: flex;
     justify-content: space-between;
-    padding: 24px 200px;
+    padding: 1.5rem 200px;
 }
 
 .top-page {
@@ -41,16 +42,16 @@ p {
     display: flex;
     padding: 200px;
     justify-content: space-between;
-    gap: 24px;
+    gap: 1.5rem;
 }
 
 .title {
-    font-size: 48px;
+    font-size: 3rem;
     font-weight: 900;
 }
 
 .top-links {
-    font-size: 18px;
+    font-size: 1.125rem;
     display: flex;
     justify-content: space-between;
     align-items: center;
@@ -60,7 +61,7 @@ p {
     color:#F9FAF8;
     background-color: #3882F6;
     border: none;
-    padding: 8px 32px;
+    padding: 0.5rem 2rem;
     border-radius: 10px;
     font-weight: 600;
 }
@@ -68,7 +69,7 @@ p {
 .info-header {
     display: flex;
     justify-content: center;
-    font-size: 36px;
+    font-size: 2.25rem;
     color: #1F2937;
     font-weight: 900;
 }
@@ -76,8 +77,8 @@ p {
 .mid-page {
     display: flex;
     justify-content: center;
-    padding: 24px;
-    gap: 48px;
+    padding: 1.5rem;
+    gap: 3rem;
 }
 
 .info-pair {
@@ -89,7 +90,7 @@ p {
 .square-img {
     height: 240px;
     width: 240px;
-    border: 8px solid #3882F6;
+    border: 0.5rem solid #3882F6;
     border-radius: 10px;
     overflow: hidden;
 }
@@ -103,7 +104,7 @@ p {
 }
 
 .quote-body {
-    font-size: 36px;
+    font-size: 2.25rem;
     font-style: italic;
     color: #1F2937;
     padding: 0px 400px;
@@ -112,15 +113,15 @@ p {
 
 .quote-author {
     font-weight: 900;
-    padding: 0px 340px;
+    padding: 0 340px;
     text-align: right;
-    margin-bottom: 100px;
+    margin-bottom: 6rem;
 }
 
 .footer {
     color: #F9FAF8;
     text-align: center;
-    padding: 24px;
+    padding: 1.5rem;
 }
 
 .call {
@@ -128,27 +129,27 @@ p {
     background-color: #3882F6;
     border-radius: 10px;
     margin: 100px 200px;
-    padding: 48px 300px;
+    padding: 3rem 300px;
     justify-content: space-between;
     align-items: center;
 }
 
 .call-text {
     color:#F9FAF8;
-    font-size: 18px;
+    font-size: 1.125rem;
 }
 
 .call-bold {
     font-weight: 700;
-    font-size: 24px;
+    font-size: 1.5rem;
 }
 
 .call-button {
     color:#F9FAF8;
-    font-size: 18px;
+    font-size: 1.125rem;
     background-color: #3882F6;
     border: 2px solid white;
-    padding: 8px 64px;
+    padding: 0.5rem 4rem;
     border-radius: 10px;
     font-weight: 600;
 }


### PR DESCRIPTION
For font size and spacing you could also choose to use rem. They're relative to the base font size. For responsive and accessibility (control/command +/-) reasons this base unit may update, and if you use rem, the rest of the spacing/font sizes follow.